### PR TITLE
automatically install timezone packages and set symlink to localtime-file

### DIFF
--- a/FORMULA
+++ b/FORMULA
@@ -1,6 +1,6 @@
 name: timezone
-os: Debian, Suse
-os_family: Debian, Suse
+os: Debian, Redhat, Suse
+os_family: Debian, Redhat, Suse
 version: 201504
 release: 1
 minimum_version: 2015.5

--- a/FORMULA
+++ b/FORMULA
@@ -1,6 +1,6 @@
 name: timezone
-os: Debian, Redhat, Suse
-os_family: Debian, Redhat, Suse
+os: Debian, RedHat, Suse
+os_family: Debian, RedHat, Suse
 version: 201504
 release: 1
 minimum_version: 2015.5

--- a/FORMULA
+++ b/FORMULA
@@ -1,6 +1,6 @@
 name: timezone
-os: RedHat, Debian, Ubuntu, Suse, FreeBSD
-os_family: RedHat, Debian, Suse, FreeBSD
+os: Debian, Suse
+os_family: Debian, Suse
 version: 201504
 release: 1
 minimum_version: 2015.5

--- a/FORMULA
+++ b/FORMULA
@@ -1,0 +1,8 @@
+name: timezone
+os: Debian, RedHat, Suse
+os_family: Debian, RedHat, Suse
+version: 201504
+release: 1
+minimum_version: 2015.5
+summary: Formula for timezone management
+description: Formula for managing timezone settings

--- a/README.rst
+++ b/README.rst
@@ -28,4 +28,4 @@ Default values are:
 timezone: 'Europe/Berlin'
 utc: True
 
-See mopidy/pillar.example.
+See timezone/pillar.example.

--- a/timezone/init.sls
+++ b/timezone/init.sls
@@ -2,8 +2,21 @@
 
 {%- set timezone = salt['pillar.get']('timezone:name', 'Europe/Berlin') %}
 {%- set utc = salt['pillar.get']('timezone:utc', True) %}
+{% from "timezone/map.jinja" import confmap with context %}
 
 timezone_setting:
   timezone.system:
     - name: {{ timezone }}
     - utc: {{ utc }}
+
+timezone_packages:
+  pkg.installed:
+    - name: {{ confmap.pkgname }}
+
+timezone_symlink:
+  file.symlink:
+    - name: {{ confmap.path_localtime }}
+    - target: {{ confmap.path_zoneinfo }}{{ timezone }}
+    - force: true
+    - require:
+      - pkg: {{ confmap.pkgname }}

--- a/timezone/init.sls
+++ b/timezone/init.sls
@@ -15,6 +15,6 @@ timezone.packages:
 
 file.symlink:
   - name: {{ confmap.path-localtime }}
-  - target: {{ path-zoneinfo }}{{ timezone }}
+  - target: {{ confmap.path-zoneinfo }}{{ timezone }}
   - require:
     - pkg: {{ confmap.pkgname }}

--- a/timezone/init.sls
+++ b/timezone/init.sls
@@ -2,8 +2,19 @@
 
 {%- set timezone = salt['pillar.get']('timezone:name', 'Europe/Berlin') %}
 {%- set utc = salt['pillar.get']('timezone:utc', True) %}
+{% from "timezone/map.jinja" import confmap with context %}
 
 timezone_setting:
   timezone.system:
     - name: {{ timezone }}
     - utc: {{ utc }}
+
+timezone.packages:
+  pkg.installed:
+    - name: {{ confmap.pkgname }}
+
+{{ confmap.path-localtime }}:
+  file.symlink:
+    - target: {{ path-zoneinfo }}{{ timezone }}
+    - require:
+      - pkg: {{ confmap.pkgname }}

--- a/timezone/init.sls
+++ b/timezone/init.sls
@@ -9,11 +9,11 @@ timezone_setting:
     - name: {{ timezone }}
     - utc: {{ utc }}
 
-timezone.packages:
+timezone_packages:
   pkg.installed:
     - name: {{ confmap.pkgname }}
 
-timezone.symlink:
+timezone_symlink:
   file.symlink:
     - name: {{ confmap.path_localtime }}
     - target: {{ confmap.path_zoneinfo }}{{ timezone }}

--- a/timezone/init.sls
+++ b/timezone/init.sls
@@ -13,8 +13,10 @@ timezone.packages:
   pkg.installed:
     - name: {{ confmap.pkgname }}
 
-file.symlink:
-  - name: {{ confmap.path-localtime }}
-  - target: {{ confmap.path-zoneinfo }}{{ timezone }}
-  - require:
-    - pkg: {{ confmap.pkgname }}
+timezone.symlink:
+  file.symlink:
+    - name: {{ confmap.path-localtime }}
+    - target: {{ confmap.path-zoneinfo }}{{ timezone }}
+    - force: true
+    - require:
+      - pkg: {{ confmap.pkgname }}

--- a/timezone/init.sls
+++ b/timezone/init.sls
@@ -13,8 +13,8 @@ timezone.packages:
   pkg.installed:
     - name: {{ confmap.pkgname }}
 
-{{ confmap.path-localtime }}:
-  file.symlink:
-    - target: {{ path-zoneinfo }}{{ timezone }}
-    - require:
-      - pkg: {{ confmap.pkgname }}
+file.symlink:
+  - name: {{ confmap.path-localtime }}
+  - target: {{ path-zoneinfo }}{{ timezone }}
+  - require:
+    - pkg: {{ confmap.pkgname }}

--- a/timezone/init.sls
+++ b/timezone/init.sls
@@ -15,8 +15,8 @@ timezone.packages:
 
 timezone.symlink:
   file.symlink:
-    - name: {{ confmap.path-localtime }}
-    - target: {{ confmap.path-zoneinfo }}{{ timezone }}
+    - name: {{ confmap.path_localtime }}
+    - target: {{ confmap.path_zoneinfo }}{{ timezone }}
     - force: true
     - require:
       - pkg: {{ confmap.pkgname }}

--- a/timezone/map.jinja
+++ b/timezone/map.jinja
@@ -1,0 +1,9 @@
+{% set map = {
+    'Suse': {
+        'path-localtime': '/etc/localtime',
+        'path-zoneinfo': '/usr/share/zoneinfo/',
+        'pkgname': 'timezone',
+    },
+} %}
+
+{% set confmap = map.get(grains.os_family) %}

--- a/timezone/map.jinja
+++ b/timezone/map.jinja
@@ -1,7 +1,7 @@
 {% set map = {
     'Suse': {
-        'path-localtime': '/etc/localtime',
-        'path-zoneinfo': '/usr/share/zoneinfo/',
+        'path_localtime': '/etc/localtime',
+        'path_zoneinfo': '/usr/share/zoneinfo/',
         'pkgname': 'timezone',
     },
 } %}

--- a/timezone/map.jinja
+++ b/timezone/map.jinja
@@ -4,6 +4,11 @@
         'path_zoneinfo': '/usr/share/zoneinfo/',
         'pkgname': 'tzdata',
     },
+    'Redhat': {
+        'path_localtime': '/etc/localtime',
+        'path_zoneinfo': '/usr/share/zoneinfo/',
+        'pkgname': 'tzdata',
+    },
     'Suse': {
         'path_localtime': '/etc/localtime',
         'path_zoneinfo': '/usr/share/zoneinfo/',

--- a/timezone/map.jinja
+++ b/timezone/map.jinja
@@ -1,4 +1,9 @@
 {% set map = {
+    'Debian': {
+        'path_localtime': '/etc/localtime',
+        'path_zoneinfo': '/usr/share/zoneinfo/',
+        'pkgname': 'tzdata',
+    },
     'Suse': {
         'path_localtime': '/etc/localtime',
         'path_zoneinfo': '/usr/share/zoneinfo/',

--- a/timezone/map.jinja
+++ b/timezone/map.jinja
@@ -1,0 +1,19 @@
+{% set map = {
+    'Debian': {
+        'path_localtime': '/etc/localtime',
+        'path_zoneinfo': '/usr/share/zoneinfo/',
+        'pkgname': 'tzdata',
+    },
+    'Redhat': {
+        'path_localtime': '/etc/localtime',
+        'path_zoneinfo': '/usr/share/zoneinfo/',
+        'pkgname': 'tzdata',
+    },
+    'Suse': {
+        'path_localtime': '/etc/localtime',
+        'path_zoneinfo': '/usr/share/zoneinfo/',
+        'pkgname': 'timezone',
+    },
+} %}
+
+{% set confmap = map.get(grains.os_family) %}


### PR DESCRIPTION
these changes will work for Debian, RedHat and Suse, other distributions can easily be added in the map.jinja file
it will install the related package containing the timezone-data and linking from those freshly installed timezone-data via symlink to /etc/localtime
